### PR TITLE
[codex] 重写 krlibc 数字格式化实现

### DIFF
--- a/kernel/krlibc.cpp
+++ b/kernel/krlibc.cpp
@@ -510,94 +510,78 @@ int skip_atoi(const char **s)
  */
 size_t wnumber(Writer *writer, num_formatter_t fmter, num_fmt_type type) // NOLINT
 {
-    char         c = 0;
+    if (!writer || !writer->handler || fmter.base < 2 || fmter.base > 36) { return 0; }
+
     char         tmp[65];
-    int          sign      = 0;
-    const char  *digits    = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    int          i         = 0; // index for tmp
-    int64_t      size      = (int64_t)fmter.size;
-    int64_t      precision = (int64_t)fmter.precision;
-    size_t       base      = fmter.base;
-    WriteHandler write     = writer->handler;
-    size_t       result    = 0;
+    const char  *digits  = type.small ? "0123456789abcdefghijklmnopqrstuvwxyz"
+                                      : "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    WriteHandler write   = writer->handler;
+    size_t       result  = 0;
+    uint64_t     value   = (uint64_t)fmter.num;
+    char         sign    = 0;
+    char         prefix0 = 0;
+    char         prefix1 = 0;
 
-    if (type.small) digits = "0123456789abcdefghijklmnopqrstuvwxyz";
-    if (type.left) type.zeropad = false; // if left adjust, zero padding is not allowed
-    if (base < 2 || base > 36) return 0; // Invalid base
-
-    c = (type.zeropad) ? '0' : ' ';
-
-    /* Check sign */
     if (type.sign && (int64_t)fmter.num < 0)
     {
-        sign      = '-';
-        fmter.num = -(int64_t)fmter.num;
+        int64_t signed_value = (int64_t)fmter.num;
+        sign                 = '-';
+        value                = (uint64_t)(-(signed_value + 1)) + 1;
     }
     else if (type.plus) { sign = '+'; }
     else if (type.space) { sign = ' '; }
-    else { sign = 0; }
 
-    if (sign) size--;
-
-    /* Special like 0x, 0 */
     if (type.special)
     {
-        if (base == 16) { size -= 2; }
-        else if (base == 8) { size--; }
-    }
-
-    i = 0;
-    if (fmter.num == 0) { tmp[i++] = '0'; }
-    else
-    {
-        while (fmter.num != 0)
+        if (fmter.base == 8) { prefix0 = '0'; }
+        else if (fmter.base == 16)
         {
-            tmp[i++]  = digits[(uint64_t)fmter.num % (uint64_t)base];
-            fmter.num = (uint64_t)fmter.num / (uint64_t)fmter.base;
-        }
-    }
-    if (i > precision) precision = i; // precision = max(precision, i);
-    size -= precision;
-
-    /* If type no include LEFT or ZEROPAD */
-    if (!(type.zeropad || type.left))
-    {
-        /* Fill in the space */
-        while (size-- > 0)
-            write(writer, ' '), result++;
-    }
-
-    /* Write the sign */
-    if (sign) write(writer, (char)sign), result++;
-
-    /* Write the prefix */
-    if (type.special)
-    {
-        if (base == 8) { write(writer, '0'), result++; }
-        else if (base == 16)
-        {
-            write(writer, '0'), result++;
-            write(writer, digits[33]), result++; // 33 is 'x' or 'X'
+            prefix0 = '0';
+            prefix1 = type.small ? 'x' : 'X';
         }
     }
 
-    if (!(type.left))
+    size_t digit_count = 0;
+    do
     {
-        /* Write the padding */
-        while (size-- > 0)
-            write(writer, c), result++;
-    }
+        tmp[digit_count++] = digits[value % (uint64_t)fmter.base];
+        value /= (uint64_t)fmter.base;
+    } while (value != 0);
 
-    /* Write the zero padding */
-    while (i < precision--)
-        write(writer, '0'), result++;
-    /* Write the number */
-    while (i-- > 0)
-        write(writer, tmp[i]), result++;
+    size_t prefix_width      = (prefix0 != 0 ? 1 : 0) + (prefix1 != 0 ? 1 : 0);
+    size_t precision_width   = fmter.precision > digit_count ? fmter.precision : digit_count;
+    size_t precision_padding = precision_width - digit_count;
+    size_t content_width     = precision_width + prefix_width + (sign != 0 ? 1 : 0);
+    size_t field_padding     = fmter.size > content_width ? fmter.size - content_width : 0;
+    bool   zero_field        = type.zeropad && !type.left;
 
-    /* LEFT adjust */
-    while (size-- > 0)
+    while (!type.left && !zero_field && field_padding > 0)
+    {
+        field_padding--;
         write(writer, ' '), result++;
+    }
+
+    if (sign != 0) write(writer, sign), result++;
+    if (prefix0 != 0) write(writer, prefix0), result++;
+    if (prefix1 != 0) write(writer, prefix1), result++;
+
+    while (zero_field && field_padding > 0)
+    {
+        field_padding--;
+        write(writer, '0'), result++;
+    }
+    while (precision_padding > 0)
+    {
+        precision_padding--;
+        write(writer, '0'), result++;
+    }
+    while (digit_count-- > 0)
+        write(writer, tmp[digit_count]), result++;
+    while (type.left && field_padding > 0)
+    {
+        field_padding--;
+        write(writer, ' '), result++;
+    }
 
     return result;
 }

--- a/tests/test_krlibc_formatter.py
+++ b/tests/test_krlibc_formatter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class KrlibcFormatterTests(unittest.TestCase):
+    def test_number_formatter_has_no_linux_vsprintf_markers(self) -> None:
+        source = (ROOT / "kernel/krlibc.cpp").read_text(encoding="utf-8")
+
+        self.assertNotIn("digits[33]", source)
+        self.assertNotIn("If type no include LEFT or ZEROPAD", source)
+        self.assertNotIn("LEFT adjust", source)
+        self.assertNotIn("Write the zero padding", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- 重写 krlibc 数字格式化路径，去除 Linux `vsprintf` 风格来源标记和历史实现痕迹。
- 增加来源回归测试，防止重新引入旧 formatter 标记。

## 关联 Issue
Refs #25

## 验证
- `python3 -m unittest tests.test_krlibc_formatter.KrlibcFormatterTests.test_number_formatter_has_no_linux_vsprintf_markers -v`
- `git diff --check`

## 开发说明
本PR内容使用Codex工具与gpt-5.5 xhigh模型开发。
