### PR TITLE
[codex] 修正根许可证版权声明

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2026] [XINGJI Interactive Software Team]
+   Copyright 2026 XINGJI Interactive Software Team
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 概要
- 将 Apache-2.0 Appendix 中仍带方括号的版权占位格式改为实际项目版权声明。
- 避免 `Copyright [yyyy] [name of copyright owner]` / `Copyright [2026] [...]` 这类模板占位残留。

## 关联 Issue
Refs #30

## 验证
- `LICENSE placeholder check: ISSUE_30_LICENSE_OK`
- `git diff --check`

## 开发说明
本PR内容使用Codex工具与gpt-5.5 xhigh模型开发。
