### PR TITLE
Dynamicly load busybox_alias_applets

### DIFF
--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -69,6 +69,39 @@ static const char *busybox_alias_applets[] = {
     "unzip",   "uptime",  "usleep",   "vi",       "wc",       "wget",     "which",   "whoami",
     "xargs",   "xxd",     "xz",       "xzcat",    "zcat",     NULL,
 };//暴力枚举这一块，好像只能这么做了
+  //Maybe we can try to load this applet when vfs inited.
+
+static void load_busybox_alias_applets()
+{
+    if (current_user == NULL) return;
+
+    char setfile_path[256];
+    memset(setfile_path, 0, 256);
+    strcat(setfile_path, "/etc/busybox/alias/applets.dat");
+    vfs_node_t vfp = vfs_open(setfile_path);
+    if (!vfp) return;
+    char tmp[1024];
+    if(vfp->size > sizeof(tmp)) goto cleanup;
+    vfs_read(vfp, tmp, 0, vfp->size);
+    char alias[8];
+    memset(alias, 0, 8);
+    int applet_index = 0, alias_index = 0;
+    for(int i = 0; tmp[i] != EOF, i++)
+    {
+	if(tmp[i] == ',')
+	{
+	    strcpy(busybox_alias_applets[applet_index], alias);
+	    applet_index ++;
+	    continue;
+	}
+	alias[alias_index] = tmp[i];
+	alias_index ++;
+    }
+    strcpy(busybox_alias_applets[applet_index], alias);
+
+cleanup:
+    vfs_close(v)
+}
 
 static const char *busybox_binary_path = "/apps/busybox";
 
@@ -209,17 +242,13 @@ void init_time()
     SettingsDataFileFormat sdff;
     memset(&sdff, 0, sizeof(sdff));
     size_t read_size = v->size < sizeof(sdff) ? (size_t)v->size : sizeof(sdff);
-    if (read_size == 0 || vfs_read(v, &sdff, 0, read_size) == -1)
-    {
-        vfs_close(v);
-        return;
-    }
-
+    if (read_size == 0 || vfs_read(v, &sdff, 0, read_size) == -1) goto cleanup;
     clock_hour_offset = sdff.ClockHourOffset;
 
     if (clock_hour_offset < 0)
         clock_hour_offset = 0;
 
+cleanup:
     vfs_close(v);
 }
 


### PR DESCRIPTION
'' I dont think writing the aliases statically is a good idea, so I'm now writing some functions to load the aliases dynamically

- do not accept this PR before the solutions are deployed