### PR TITLE
修复许可证分发与来源记录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ build.ninja
 XJ380/
 
 venv/
+
+# Local audit notes
+/docs/LICENSE_AUDIT_2026-08-08.md

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -8,8 +8,9 @@ binary distribution. The command-line image installs the repository notices at
 
 | Component | License | Source location | Image location |
 | --- | --- | --- | --- |
+| XJ380 project | Apache-2.0 | `LICENSE` | `LICENSE` |
 | FatFs | ChaN permissive license | `driver/fs/fatfs/ff.cpp` | `fatfs.txt` |
-| lwIP | BSD-style | `kmod/netserver/lwip/` | `lwip.txt` |
+| lwIP | BSD-style | compiled files under `kmod/netserver/lwip/` | `lwip-notice-full.txt` |
 | musl ELF definitions | MIT | `include/elf.h`; `third_party/musl-elf` | `musl-elf.txt`; `third-party compliance bundle` |
 | Rust alloc/compiler_builtins archive | Apache-2.0 OR MIT | `liballoc-x86_64.a`; `third_party/rust-runtime` | `liballoc.txt`; `third-party compliance bundle` |
 | talc allocator | MIT | `liballoc-x86_64.a`; `third_party/talc` | `third-party compliance bundle` |
@@ -17,8 +18,7 @@ binary distribution. The command-line image installs the repository notices at
 | libutf | MIT | `kernel/utflib.cpp`; `include/proto.hpp`; `third_party/libutf` | `third-party compliance bundle` |
 | XJ380 project notices | Project notice | `THIRD_PARTY_NOTICES.md` | `THIRD_PARTY_NOTICES.md` |
 | MikanOS hankaku font | Apache-2.0 | `third_party/mikanos-hankaku`; `font/hankaku.bin` | `third-party compliance bundle` |
-| maple-font | OFL-1.1 | `third_party/maple-font/LICENSE`; `font/ttf/LICENSES.md`; `font/ttf/XJ380C.ttf` | `third-party compliance bundle` |
-| Source Han Sans font | OFL-1.1 | `third_party/source-han-sans/LICENSE`; `font/ttf/LICENSES.md`; `font/ttf/XJ380F.ttf` | `third-party compliance bundle` |
+| MikanOS-derived framebuffer header | Apache-2.0 for derived portions | `include/efi/fbc.h`; `third_party/mikanos-hankaku/SOURCE.md` | `third-party compliance bundle` |
 
 ## Retained Linux compatibility payload
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,7 +9,7 @@ generates a distributable bundle at `out/compliance/third-party`.
 | Component | Selected license | Material |
 |---|---|---|
 | musl ELF definitions | MIT | `third_party/musl-elf` |
-| lwIP | BSD-3-Clause | `kmod/netserver/lwip` |
+| lwIP | BSD-style notices | compiled files under `kmod/netserver/lwip`; `licenses/lwip-notice-full.txt` |
 | FatFs | BSD-style permissive | `driver/fs/fatfs` |
 | dr_mp3 | MIT-0 OR Unlicense | `include/dr_mp3.h` |
 | libvterm | MIT | `third_party/libvterm/LICENSE` |
@@ -19,6 +19,7 @@ generates a distributable bundle at `out/compliance/third-party`.
 | talc allocator | MIT | `third_party/talc/LICENSE.md`; `third_party/talc/SOURCE.md`; `liballoc-x86_64.a` |
 | BusyBox 1.31.1 | GPL-2.0-only | `third_party/busybox-source` |
 | MikanOS hankaku font | Apache-2.0 | `third_party/mikanos-hankaku/LICENSE`; `third_party/mikanos-hankaku/SOURCE.md`; `third_party/mikanos-hankaku/hankaku.txt`; `font/hankaku.bin` |
+| MikanOS-derived framebuffer header | Apache-2.0 for derived portions | `include/efi/fbc.h`; `third_party/mikanos-hankaku/LICENSE`; `third_party/mikanos-hankaku/SOURCE.md` |
 | libutf | MIT | `third_party/libutf/LICENSE`; `third_party/libutf/SOURCE.md`; `kernel/utflib.cpp`; `include/proto.hpp` |
 | Linux UAPI ioctl definitions | GPL-2.0 WITH Linux-syscall-note | `third_party/linux-uapi`; `include/ioctl.h` |
 
@@ -33,3 +34,7 @@ remain byte-identical.
 `driver/dma.cpp`, `driver/dma_plan.h`, `kmod/netserver/netserver.cpp`, and
 `kmod/netserver/arch/sys_arch.*` are project-local implementations. The
 netserver continues to link the separately licensed BSD-3-Clause lwIP source.
+
+`include/efi/fbc.h` contains portions derived from MikanOS and retains the
+Apache-2.0 attribution in the source file. The MikanOS source record is kept in
+`third_party/mikanos-hankaku/SOURCE.md`.

--- a/licenses/fatfs.txt
+++ b/licenses/fatfs.txt
@@ -1,8 +1,15 @@
-FatFs is copyright (C) 2026, ChaN, all right reserved.
+FatFs - Generic FAT Filesystem Module R0.15 w/patch3
 
-FatFs module is an open source software. Redistribution and use in source and
-binary forms, with or without modification, are permitted provided that the
-following condition is retained: this copyright notice and disclaimer are
-retained in the source code and binary redistributions.
+Copyright (C) 2022, ChaN, all right reserved.
 
-This software is provided "AS IS" without any warranty, express or implied.
+FatFs module is an open source software. Redistribution and use of FatFs in
+source and binary forms, with or without modification, are permitted provided
+that the following condition is met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this condition and the following disclaimer.
+
+This software is provided by the copyright holder and contributors "AS IS"
+and any warranties related to this software are DISCLAIMED. The copyright
+owner or contributors be NOT LIABLE for any damages caused by use of this
+software.

--- a/licenses/lwip-notice-full.txt
+++ b/licenses/lwip-notice-full.txt
@@ -1,0 +1,357 @@
+lwIP redistribution notices for the netserver.sys compiled source subset.
+
+The notices below are copied verbatim from the source files listed in the
+compiled-source index. Duplicate notice blocks are included once.
+
+===== kmod/netserver/lwip/core/def.c =====
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Simon Goldschmidt
+ *
+ */
+
+===== kmod/netserver/lwip/core/dns.c =====
+
+/*
+ * Port to lwIP from uIP
+ * by Jim Pettinato April 2007
+ *
+ * security fixes and more by Simon Goldschmidt
+ *
+ * uIP version Copyright (c) 2002-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+===== kmod/netserver/lwip/core/init.c =====
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ */
+
+===== kmod/netserver/lwip/core/inet_chksum.c =====
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+===== kmod/netserver/lwip/core/ip.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/mem.c =====
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *         Simon Goldschmidt
+ *
+ */
+
+===== kmod/netserver/lwip/core/memp.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/netif.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/pbuf.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/stats.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/sys.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/tcp.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/tcp_in.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/tcp_out.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/udp.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/timeouts.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/ipv4/dhcp.c =====
+
+/*
+ * Copyright (c) 2001-2004 Leon Woestenberg <leon.woestenberg@gmx.net>
+ * Copyright (c) 2001-2004 Axon Digital Design B.V., The Netherlands.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ * The Swedish Institute of Computer Science and Adam Dunkels
+ * are specifically granted permission to redistribute this
+ * source code.
+ *
+ * Author: Leon Woestenberg <leon.woestenberg@gmx.net>
+ *
+ */
+
+===== kmod/netserver/lwip/core/ipv4/etharp.c =====
+
+/*
+ * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
+ * Copyright (c) 2003-2004 Leon Woestenberg <leon.woestenberg@axon.tv>
+ * Copyright (c) 2003-2004 Axon Digital Design B.V., The Netherlands.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ */
+
+===== kmod/netserver/lwip/core/ipv4/icmp.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/ipv4/ip4.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/core/ipv4/ip4_addr.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/netif/ethernet.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/api/api_lib.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/api/api_msg.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/api/err.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/api/netbuf.c =====
+
+[duplicate notice block shown above]
+
+===== kmod/netserver/lwip/api/netifapi.c =====
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ */
+
+===== kmod/netserver/lwip/api/tcpip.c =====
+
+[duplicate notice block shown above]

--- a/tests/test_license_compliance.py
+++ b/tests/test_license_compliance.py
@@ -12,6 +12,27 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class LicenseComplianceTests(unittest.TestCase):
+    def test_project_license_and_fatfs_notice_are_present_and_exact(self) -> None:
+        project_license = (ROOT / "LICENSE").read_text(encoding="utf-8")
+        fatfs_notice = (ROOT / "licenses/fatfs.txt").read_text(encoding="utf-8")
+
+        self.assertIn("Apache License", project_license)
+        self.assertIn("Copyright (C) 2022, ChaN", fatfs_notice)
+        self.assertNotIn("Copyright (C) 2026, ChaN", fatfs_notice)
+
+    def test_image_staging_includes_project_license(self) -> None:
+        staging = (ROOT / "tools/ninja_build.py").read_text(encoding="utf-8")
+        self.assertIn('cp(ROOT / "LICENSE", destination / "LICENSE")', staging)
+
+    def test_lwip_notice_indexes_every_compiled_source(self) -> None:
+        generator = (ROOT / "tools/gen_ninja.py").read_text(encoding="utf-8")
+        notice = (ROOT / "licenses/lwip-notice-full.txt").read_text(encoding="utf-8")
+        items = generator.split("lwip_c = [", 1)[1].split("]", 1)[0]
+        compiled = [line.strip().strip('\",') for line in items.splitlines() if '"lwip/' in line]
+        self.assertTrue(compiled)
+        for item in compiled:
+            self.assertIn(f"kmod/netserver/{item}", notice)
+
     def test_elf_header_uses_declared_permissive_upstream(self) -> None:
         header = (ROOT / "include/elf.h").read_text(encoding="utf-8")
 
@@ -116,6 +137,17 @@ class LicenseComplianceTests(unittest.TestCase):
         )
         self.assertTrue(components["mikanos-hankaku"]["bundle_source"])
 
+    def test_mikanos_framebuffer_provenance_is_packaged(self) -> None:
+        manifest = json.loads(
+            (ROOT / "third_party/compliance-manifest.json").read_text(encoding="utf-8")
+        )
+        components = {component["slug"]: component for component in manifest["components"]}
+        framebuffer = components["mikanos-framebuffer"]
+
+        self.assertEqual("Apache-2.0 for derived portions", framebuffer["license"])
+        self.assertIn("include/efi/fbc.h", framebuffer["source_files"])
+        self.assertTrue(framebuffer["bundle_source"])
+
     def test_third_party_manifest_references_existing_materials(self) -> None:
         manifest = json.loads(
             (ROOT / "third_party/compliance-manifest.json").read_text(encoding="utf-8")
@@ -147,7 +179,11 @@ class LicenseComplianceTests(unittest.TestCase):
             )
 
             self.assertTrue((destination / "MANIFEST.json").is_file())
+            self.assertTrue((destination / "notices/LICENSE").is_file())
             self.assertTrue((destination / "notices/THIRD_PARTY_NOTICES.md").is_file())
+            self.assertTrue((destination / "licenses/lwip/lwip-notice-full.txt").is_file())
+            self.assertTrue((destination / "licenses/fatfs/fatfs.txt").is_file())
+            self.assertTrue((destination / "sources/mikanos-framebuffer/fbc.h").is_file())
             self.assertTrue(
                 (destination / "sources/busybox/busybox-1.31.1.tar.bz2").is_file()
             )

--- a/third_party/compliance-manifest.json
+++ b/third_party/compliance-manifest.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "components": [
     {"name":"musl ELF definitions","slug":"musl-elf","license":"MIT","license_files":["third_party/musl-elf/COPYRIGHT","third_party/musl-elf/SOURCE.md"],"source_files":["include/elf.h","third_party/musl-elf/SOURCE.md"],"bundle_source":false},
-    {"name":"lwIP","slug":"lwip","license":"BSD-3-Clause","license_files":["kmod/netserver/lwip/core/init.c"],"source_files":["kmod/netserver/lwip"],"bundle_source":false},
-    {"name":"FatFs","slug":"fatfs","license":"BSD-style","license_files":["driver/fs/fatfs/ff.cpp"],"source_files":["driver/fs/fatfs"],"bundle_source":false},
+    {"name":"lwIP","slug":"lwip","license":"BSD-style","license_files":["licenses/lwip-notice-full.txt"],"source_files":["kmod/netserver/lwip"],"bundle_source":false},
+    {"name":"FatFs","slug":"fatfs","license":"BSD-style","license_files":["licenses/fatfs.txt"],"source_files":["driver/fs/fatfs"],"bundle_source":false},
     {"name":"dr_mp3","slug":"dr-mp3","license":"MIT-0 OR Unlicense","license_files":["include/dr_mp3.h"],"source_files":["include/dr_mp3.h"],"bundle_source":false},
     {"name":"libvterm","slug":"libvterm","license":"MIT","license_files":["third_party/libvterm/LICENSE"],"source_files":["third_party/libvterm"],"bundle_source":false},
     {"name":"Mbed TLS","slug":"mbedtls","license":"Apache-2.0","license_files":["third_party/mbedtls-src/LICENSE","third_party/mbedtls-license-selection.json"],"source_files":["third_party/mbedtls-src"],"bundle_source":false},
@@ -12,6 +12,7 @@
     {"name":"talc allocator","slug":"talc","license":"MIT","license_files":["third_party/talc/LICENSE.md","third_party/talc/SOURCE.md"],"source_files":["liballoc-x86_64.a"],"bundle_source":false},
     {"name":"BusyBox","slug":"busybox","license":"GPL-2.0-only","license_files":["third_party/busybox-source/LICENSE"],"source_files":["third_party/busybox-source/busybox-1.31.1.tar.bz2","third_party/busybox-source/busybox-1.31.1.config","third_party/busybox-source/0001-date-use-clock-settime.patch","third_party/busybox-source/build.sh","third_party/busybox-source/BUILDING.md"],"bundle_source":true},
     {"name":"MikanOS hankaku font","slug":"mikanos-hankaku","license":"Apache-2.0","license_files":["third_party/mikanos-hankaku/LICENSE","third_party/mikanos-hankaku/SOURCE.md"],"source_files":["third_party/mikanos-hankaku/hankaku.txt","font/hankaku.bin"],"bundle_source":true},
+    {"name":"MikanOS-derived framebuffer header","slug":"mikanos-framebuffer","license":"Apache-2.0 for derived portions","license_files":["third_party/mikanos-hankaku/LICENSE","third_party/mikanos-hankaku/SOURCE.md"],"source_files":["include/efi/fbc.h"],"bundle_source":true},
     {"name":"libutf","slug":"libutf","license":"MIT","license_files":["third_party/libutf/LICENSE","third_party/libutf/SOURCE.md"],"source_files":["kernel/utflib.cpp","include/proto.hpp"],"bundle_source":false},
     {"name":"Linux UAPI ioctl definitions","slug":"linux-uapi","license":"GPL-2.0 WITH Linux-syscall-note","license_files":["third_party/linux-uapi/COPYING","third_party/linux-uapi/GPL-2.0","third_party/linux-uapi/Linux-syscall-note","third_party/linux-uapi/SOURCE.md"],"source_files":["include/ioctl.h"],"bundle_source":false}
   ]

--- a/tools/gen_ninja.py
+++ b/tools/gen_ninja.py
@@ -805,7 +805,9 @@ def main() -> None:
     compliance_manifest = json.loads((ROOT / compliance_manifest_path).read_text(encoding="utf-8"))
     compliance_inputs = [
         Path("tools/package_third_party.py"),
+        Path("tools/generate_lwip_notice.py"),
         compliance_manifest_path,
+        Path("LICENSE"),
         Path("THIRD_PARTY_NOTICES.md"),
     ]
     for component in compliance_manifest["components"]:

--- a/tools/generate_lwip_notice.py
+++ b/tools/generate_lwip_notice.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Generate exact redistribution notices for the compiled lwIP subset."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def compiled_sources() -> list[str]:
+    generator = (ROOT / "tools/gen_ninja.py").read_text(encoding="utf-8")
+    block = generator.split("lwip_c = [", 1)[1].split("]", 1)[0]
+    return [line.strip().strip('\",') for line in block.splitlines() if '"lwip/' in line]
+
+
+def license_blocks(source: str) -> list[str]:
+    blocks = re.findall(r"/\*.*?\*/", source, re.DOTALL)
+    return [
+        block.strip()
+        for block in blocks
+        if re.search(r"Copyright|Redistribution and use|All rights reserved|following disclaimer", block, re.I)
+    ]
+
+
+def generate() -> str:
+    output = [
+        "lwIP redistribution notices for the netserver.sys compiled source subset.",
+        "",
+        "The notices below are copied verbatim from the source files listed in the",
+        "compiled-source index. Duplicate notice blocks are included once.",
+        "",
+    ]
+    seen: set[str] = set()
+    for relative in compiled_sources():
+        source_path = ROOT / "kmod/netserver" / relative
+        if not source_path.is_file():
+            raise FileNotFoundError(source_path)
+        output.extend([f"===== kmod/netserver/{relative} =====", ""])
+        blocks = license_blocks(source_path.read_text(encoding="utf-8"))
+        if not blocks:
+            raise RuntimeError(f"no license block found in {source_path}")
+        for block in blocks:
+            if block in seen:
+                output.extend(["[duplicate notice block shown above]", ""])
+                continue
+            seen.add(block)
+            output.extend([block, ""])
+    return "\n".join(output).rstrip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--write-repository", action="store_true")
+    args = parser.parse_args()
+    if args.write_repository:
+        (ROOT / "licenses/lwip-notice-full.txt").write_text(generate(), encoding="utf-8")
+        return
+    if args.output is None:
+        raise SystemExit("--output is required unless --write-repository is set")
+    output = args.output if args.output.is_absolute() else ROOT / args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(generate(), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ninja_build.py
+++ b/tools/ninja_build.py
@@ -214,6 +214,7 @@ def copy_modules(root: Path) -> None:
 def copy_license_material(root: Path, *, complete: bool) -> None:
     destination = root / "usr/share/doc/xj380/licenses"
     mkdir(destination)
+    cp(ROOT / "LICENSE", destination / "LICENSE")
     cp(ROOT / "LICENSES.md", destination / "LICENSES.md")
     cp(ROOT / "THIRD_PARTY_NOTICES.md", destination / "THIRD_PARTY_NOTICES.md")
     for license_file in sorted((ROOT / "licenses").glob("*.txt")):

--- a/tools/package_third_party.py
+++ b/tools/package_third_party.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import json
 import shutil
+import subprocess
 from pathlib import Path
 from typing import TypedDict
 
@@ -47,6 +48,7 @@ def copy_material(relative: str, destination: Path) -> list[dict[str, str]]:
 
 
 def package(output: Path) -> None:
+    subprocess.run(["python3", str(ROOT / "tools/generate_lwip_notice.py"), "--write-repository"], cwd=ROOT, check=True)
     manifest: ComplianceManifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
     if output.exists():
         shutil.rmtree(output)
@@ -67,6 +69,7 @@ def package(output: Path) -> None:
         records.append(record)
     notices = output / "notices"
     notices.mkdir()
+    shutil.copy2(ROOT / "LICENSE", notices / "LICENSE")
     shutil.copy2(ROOT / "THIRD_PARTY_NOTICES.md", notices / "THIRD_PARTY_NOTICES.md")
     (output / "MANIFEST.json").write_text(
         json.dumps({"schema_version": manifest["schema_version"], "components": records}, indent=2) + "\n",


### PR DESCRIPTION
- 修复项目许可证材料在镜像和 compliance bundle 中未完整分发的问题
- 新增并自动生成编译 lwIP 子集的完整许可证 notice
- 修正 FatFs 版权年份和授权文本
- 补充 MikanOS 衍生 framebuffer header 的 provenance 记录
- 清理当前源码树中不存在的字体许可证条目
- 增加许可证 staging、manifest 和 bundle 测试